### PR TITLE
Monocle3 debug

### DIFF
--- a/R/classify_cells.R
+++ b/R/classify_cells.R
@@ -237,7 +237,7 @@ run_classifier <- function(classifier,
   for (v in igraph::V(classifier@classification_tree)){
 
     child_cell_types <- igraph::V(classifier@classification_tree)[
-      suppressWarnings(outnei(v))]$name
+      suppressWarnings(.outnei(v))]$name
 
     if (length(child_cell_types) > 0){
       new_gate_res <- make_predictions(cds, classifier, v,
@@ -261,7 +261,7 @@ run_classifier <- function(classifier,
                                   imputed_gate_res, level_table){
 
     for (child in igraph::V(classifier@classification_tree)[
-      suppressWarnings(outnei(v))]){
+      suppressWarnings(.outnei(v))]){
       curr_level <- paste0("level", tree_levels[child])
       if(!curr_level %in% names(level_table)) {
         level_table[[curr_level]] <- "Unknown"
@@ -365,7 +365,7 @@ make_predictions <- function(cds,
   predictions <- tryCatch({
     if(is.null(cvfit)) {
       child_cell_types <- igraph::V(classifier@classification_tree)[
-        suppressWarnings(outnei(curr_node)) ]$name
+        suppressWarnings(.outnei(curr_node)) ]$name
       predictions <- matrix(FALSE, nrow=nrow(colData(cds)),
                             ncol=length(child_cell_types),
                             dimnames=list(row.names(colData(cds)),

--- a/R/get_training_sample.R
+++ b/R/get_training_sample.R
@@ -17,7 +17,7 @@ get_training_sample <- function(cds,
   ##### Find type assignment from expressed/not expressed #####
 
   child_cell_types <- igraph::V(classifier@classification_tree)[
-    suppressWarnings(outnei(curr_node)) ]$name
+    suppressWarnings(.outnei(curr_node)) ]$name
   parent <- igraph::V(classifier@classification_tree)[curr_node]$name
   if (length(child_cell_types) > 0) {
     if (length(intersect(child_cell_types, colnames(marker_scores))) == 0 &

--- a/R/train_cell_classifier.R
+++ b/R/train_cell_classifier.R
@@ -286,7 +286,7 @@ train_cell_classifier <- function(cds,
 
   for (v in igraph::V(classifier@classification_tree)){
     child_cell_types <- igraph::V(classifier@classification_tree)[
-      suppressWarnings(outnei(v))]$name
+      suppressWarnings(.outnei(v))]$name
 
     if(length(child_cell_types) > 0) {
       ### Get CDS subset for training ###
@@ -581,7 +581,7 @@ propogate_func <- function(curr_node,
                            parse_list,
                            classifier) {
   children <- igraph::V(classifier@classification_tree)[
-    suppressWarnings(outnei(curr_node))]$name
+    suppressWarnings(.outnei(curr_node))]$name
 
   if(length(children) == 0) {
     return(parse_list[[curr_node]]@expressed)

--- a/R/train_cell_classifier.R
+++ b/R/train_cell_classifier.R
@@ -299,7 +299,7 @@ train_cell_classifier <- function(cds,
           make_predictions(norm_cds,
                            classifier,
                            igraph::V(classifier@classification_tree)[
-                             suppressWarnings(innei(v))]$name,
+                             suppressWarnings(.innei(v))]$name,
                            rank_prob_ratio = 1.1,
                            s = "lambda.min")
         if(!igraph::V(classifier@classification_tree)[v]$name %in%

--- a/R/utils.R
+++ b/R/utils.R
@@ -395,7 +395,7 @@ check_markers <- function(cds,
   ##### For each node #####
   for (v in igraph::V(classifier@classification_tree)){
     child_cell_types <-
-      igraph::V(classifier@classification_tree)[suppressWarnings(outnei(v))]$name
+      igraph::V(classifier@classification_tree)[suppressWarnings(.outnei(v))]$name
 
     if(length(child_cell_types) == 0) next
 


### PR DESCRIPTION
These commits fix errors introduced with igraph version 2.10.0 when functions outnei and innei were replaced with .outnei and .innei.